### PR TITLE
Feature/allow classdefinition ignore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,9 @@
     "type": "library",
     "license": "MIT",
     "minimum-stability": "dev",
-    "require": {},
+    "require": {
+        "pimcore/pimcore": ">=5.3.0"
+    },
     "autoload": {
         "psr-4": {
             "StudioEmma\\BundleInstallationBundle\\": "src"

--- a/src/Traits/BundleInstallationTrait.php
+++ b/src/Traits/BundleInstallationTrait.php
@@ -12,10 +12,17 @@ trait BundleInstallationTrait
      * Install a Data Object Class Definition
      *
      * @param string $className
+     * @param bool $ignoreId Ignore the class ID provided by the JSON file (default true when using this bundle)
+     * @param bool $throwException Flag to throw exception instead of logging errors
+     *
      * @return \Pimcore\Model\DataObject\ClassDefinition
      * @throws \Exception
      */
-    public function installClassDefinition(string $className): \Pimcore\Model\DataObject\ClassDefinition
+    public function installClassDefinition(
+        string $className,
+        bool $ignoreId = true,
+        bool $throwException = false
+    ): \Pimcore\Model\DataObject\ClassDefinition
     {
         $class = new \Pimcore\Model\DataObject\ClassDefinition();
         $id = $class->getDao()->getIdByName($className);
@@ -32,7 +39,7 @@ trait BundleInstallationTrait
         }
 
         $json = $this->getDataFile($className, 'class');
-        \Pimcore\Model\DataObject\ClassDefinition\Service::importClassDefinitionFromJson($class, $json);
+        \Pimcore\Model\DataObject\ClassDefinition\Service::importClassDefinitionFromJson($class, $json, $throwException, $ignoreId);
 
         return $class;
     }


### PR DESCRIPTION
Since Pimcore 5.3.0 an extra argument was availabe for importing class definitions: `$ignoreId`.
This change allows the ignoreId to be passed along from within the trait. Besides that, the default value for `$ignoreId` when using the trait is `true` instead of `false`. This change however still allows the developer to explicitly pass along `$ignoreId` as false, if needed.

Because the classes can be generated by scripts, we have no certainty concerning the autogenerated class ID. So if the class ID is included in the .json export, it should be ignored to avoid errors due to class mismatching.

The minimum required Pimcore version was set to 5.3.0 to ensure compatibility.